### PR TITLE
Fix icon spread problem when they are stacked at the end of map

### DIFF
--- a/Includes/baba-is-auto/Games/Map.hpp
+++ b/Includes/baba-is-auto/Games/Map.hpp
@@ -78,6 +78,12 @@ class Map
     std::vector<Position> GetPositions(ObjectType type) const;
 
  private:
+    //! Checks position (x, y) is boundary.
+    //! \param x The x position.
+    //! \param y The y position.
+    //! \return true if it is boundary, false otherwise.
+    bool IsBoundary(std::size_t x, std::size_t y) const;
+
     std::size_t m_width = 0;
     std::size_t m_height = 0;
 

--- a/Includes/baba-is-auto/Games/Object.hpp
+++ b/Includes/baba-is-auto/Games/Object.hpp
@@ -45,7 +45,8 @@ class Object
 
     //! Adds an object type.
     //! \param type An object type to add.
-    void Add(ObjectType type);
+    //! \param isBoundary A flag to indicate it is boundary.
+    void Add(ObjectType type, bool isBoundary);
 
     //! Removes an object type.
     //! \param type An object type to remove.

--- a/Sources/baba-is-auto/Games/Map.cpp
+++ b/Sources/baba-is-auto/Games/Map.cpp
@@ -60,7 +60,7 @@ void Map::Load(std::string_view filename)
 
 void Map::AddObject(std::size_t x, std::size_t y, ObjectType type)
 {
-    m_objects.at(y * m_width + x).Add(type);
+    m_objects.at(y * m_width + x).Add(type, IsBoundary(x, y));
 }
 
 void Map::RemoveObject(std::size_t x, std::size_t y, ObjectType type)

--- a/Sources/baba-is-auto/Games/Map.cpp
+++ b/Sources/baba-is-auto/Games/Map.cpp
@@ -95,4 +95,9 @@ std::vector<Position> Map::GetPositions(ObjectType type) const
 
     return res;
 }
+
+bool Map::IsBoundary(std::size_t x, std::size_t y) const
+{
+    return x == 0 || x == m_width - 1 || y == 0 || y == m_height - 1;
+}
 }  // namespace baba_is_auto

--- a/Sources/baba-is-auto/Games/Object.cpp
+++ b/Sources/baba-is-auto/Games/Object.cpp
@@ -23,11 +23,18 @@ bool Object::operator==(const Object& rhs) const
     return m_types == rhs.m_types;
 }
 
-void Object::Add(ObjectType type)
+void Object::Add(ObjectType type, bool isBoundary)
 {
     if (m_types.find(type) != m_types.end())
     {
-        m_types[type] += 1;
+        if (isBoundary)
+        {
+            m_types[type] = 1;
+        }
+        else
+        {
+            m_types[type] += 1;
+        }
     }
     else
     {

--- a/Tests/UnitTests/UnitTests.cpp
+++ b/Tests/UnitTests/UnitTests.cpp
@@ -177,6 +177,32 @@ TEST_CASE("Map - Icon Vanishing")
     CHECK(game.GetMap().At(14, 1).HasType(ObjectType::ICON_WALL));
 }
 
+TEST_CASE("Map - Icon Spread")
+{
+    Game game(MAPS_DIR "off_limits_bug.txt");
+
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::RIGHT);
+    game.MovePlayer(Direction::LEFT);
+    game.MovePlayer(Direction::LEFT);
+
+    CHECK(game.GetMap().At(21, 3).HasType(ObjectType::ICON_WALL));
+    CHECK(game.GetMap().At(21, 4).HasType(ObjectType::ICON_WALL));
+    CHECK(game.GetMap().At(21, 5).HasType(ObjectType::ICON_WALL));
+    CHECK(game.GetMap().At(22, 3).HasType(ObjectType::ICON_EMPTY));
+    CHECK(game.GetMap().At(22, 4).HasType(ObjectType::ICON_EMPTY));
+    CHECK(game.GetMap().At(22, 5).HasType(ObjectType::ICON_FLOWER));
+    CHECK(game.GetMap().At(23, 3).HasType(ObjectType::ICON_EMPTY));
+    CHECK(game.GetMap().At(23, 4).HasType(ObjectType::ICON_EMPTY));
+    CHECK(game.GetMap().At(23, 5).HasType(ObjectType::ICON_EMPTY));
+}
+
 TEST_CASE("Preprocess - Basic")
 {
     Game game(MAPS_DIR "baba_is_you.txt");


### PR DESCRIPTION
This revision includes:
- Fix icon spread problem when they are stacked at the end of map (Resolves #41)
  - Add method 'IsBoundary()': Checks position (x, y) is boundary
  - Add unit test for checking icon spread problem