### PR TITLE
Fix CI fails on Dependabot PRs because Codecov and SonarCloud tokens are unavailable

### DIFF
--- a/.github/workflows/ubuntu-codecov.yml
+++ b/.github/workflows/ubuntu-codecov.yml
@@ -59,6 +59,7 @@ jobs:
         lcov --gcov-tool "${GCOV_TOOL}" --directory build --capture --output-file build/coverage.info
         lcov --ignore-errors unused --gcov-tool "${GCOV_TOOL}" --remove build/coverage.info '/usr/*' '*/Tests/*' --output-file build/coverage.info.cleaned
     - name: Upload coverage to Codecov
+      if: ${{ github.actor != 'dependabot[bot]' }}
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ubuntu-sonarcloud.yml
+++ b/.github/workflows/ubuntu-sonarcloud.yml
@@ -65,6 +65,7 @@ jobs:
         lcov --ignore-errors unused --gcov-tool "${GCOV_TOOL}" -r coverage.info '*/Libraries/*' -o coverage.info
         lcov --gcov-tool "${GCOV_TOOL}" -l coverage.info
     - name: SonarCloud Scan
+      if: ${{ github.actor != 'dependabot[bot]' }}
       run: sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=utilforever-github -Dsonar.login=$SONAR_TOKEN
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This revision includes:
- Fix CI fails on Dependabot PRs because Codecov and SonarCloud tokens are unavailable (Closes #76)
  - Skip Codecov and SonarCloud scans for Dependabot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to skip Codecov uploads and SonarCloud scans when triggered by automated dependency updates, reducing unnecessary scanning overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->