### PR TITLE
Add Install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release
 ```
 
-The root CMake project builds the `baba-is-auto` library, `pyBaba` extension, and `UnitTests` executable.
+vcpkg installs the dependencies declared in `vcpkg.json` during configuration. The root CMake project then builds the `baba-is-auto` library, `pyBaba` extension, and `UnitTests` executable.
 
 ### 4. Run the C++ Tests
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ For the simulator design and behavior contract, see [ARCHITECTURE.md](ARCHITECTU
 - Python 3 with development headers
 - Git
 
+Platform-specific tools:
+
+- Windows: Visual Studio 2022 with the **Desktop development with C++** workload.
+- macOS: Xcode Command Line Tools, plus `autoconf`, `autoconf-archive`, `automake`, `curl`, `libtool`, `pkg-config`, `tar`, `unzip`, and `zip`.
+- Ubuntu: `build-essential`, `autoconf`, `autoconf-archive`, `automake`, `curl`, `libtool`, `pkg-config`, `python3-dev`, `python3-setuptools`, `tar`, `unzip`, and `zip`.
+
 Set `VCPKG_ROOT` to your vcpkg checkout, or pass its toolchain file through `CMAKE_TOOLCHAIN_FILE`.
 
 ### 1. Clone

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ For the simulator design and behavior contract, see [ARCHITECTURE.md](ARCHITECTU
 ### Prerequisites
 
 - CMake 3.31.6 or later
-- vcpkg
 - A C++17 compiler
 - Python 3 with development headers
 - Git
@@ -60,16 +59,36 @@ Platform-specific tools:
 - macOS: Xcode Command Line Tools, plus `autoconf`, `autoconf-archive`, `automake`, `curl`, `libtool`, `pkg-config`, `tar`, `unzip`, and `zip`.
 - Ubuntu: `build-essential`, `autoconf`, `autoconf-archive`, `automake`, `curl`, `libtool`, `pkg-config`, `python3-dev`, `python3-setuptools`, `tar`, `unzip`, and `zip`.
 
-Set `VCPKG_ROOT` to your vcpkg checkout, or pass its toolchain file through `CMAKE_TOOLCHAIN_FILE`.
+### 1. Install vcpkg
 
-### 1. Clone
+Clone and bootstrap [vcpkg](https://github.com/microsoft/vcpkg), then expose its location to CMake.
+
+macOS and Linux:
+
+```bash
+git clone https://github.com/microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
+export VCPKG_ROOT="$PWD/vcpkg"
+```
+
+Windows PowerShell:
+
+```powershell
+git clone https://github.com/microsoft/vcpkg.git
+.\vcpkg\bootstrap-vcpkg.bat
+$env:VCPKG_ROOT = (Resolve-Path .\vcpkg)
+```
+
+The environment variable only needs to be set in the shell used to build the project. Alternatively, set `CMAKE_TOOLCHAIN_FILE` to the absolute path of `scripts/buildsystems/vcpkg.cmake` inside the vcpkg checkout.
+
+### 2. Clone
 
 ```bash
 git clone https://github.com/utilForever/baba-is-auto.git
 cd baba-is-auto
 ```
 
-### 2. Build
+### 3. Build
 
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
@@ -78,7 +97,7 @@ cmake --build build --config Release
 
 The root CMake project builds the `baba-is-auto` library, `pyBaba` extension, and `UnitTests` executable.
 
-### 3. Run the C++ Tests
+### 4. Run the C++ Tests
 
 macOS and Linux:
 


### PR DESCRIPTION
This revision includes:
- Add Install guide (Closes #23)
  - Add platform prerequisites
  - Document vcpkg setup
  - Clearify dependency installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start prerequisites with platform-specific tools for Windows, macOS, and Linux.
  * Added clearer instructions for installing vcpkg and configuring `VCPKG_ROOT` or `CMAKE_TOOLCHAIN_FILE`.
  * Reorganized cloning and building steps, including details about dependency installation and generated build outputs.
  * Improved formatting and clarity throughout the setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->